### PR TITLE
fix(DataPointCollector) removed close call to output

### DIFF
--- a/publishers/client/datapoint_collector.go
+++ b/publishers/client/datapoint_collector.go
@@ -81,7 +81,6 @@ func (d *publisherClientServer) SendDataPoints(sendRequest protocol.SendDataPoin
 // Done stops the collector.
 func (d *publisherClientServer) Done(doneRequest protocol.DoneRequest, response *protocol.DoneResponse) error {
 	d.listener.Close()
-	close(d.output)
 	*response = protocol.DoneResponse{}
 	return nil
 }


### PR DESCRIPTION
By the time this call is made the output channel is already closed.  This is due to the fact that the outtput channel is passed into the method from the parent, so its lifecycle is managed externally to the data point collector.

Closes #5